### PR TITLE
Start using snap to install certbot

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ ansible-role-letsencrypt
 =========
 
 Easy to use letsencrypt ansible role to create and renew SSL certificates.
-Current version is tested and works on __Ubuntu 16.04__.
+Current version is tested and works on __Ubuntu 16.04, 18.04, 20.04__.
 In future more platforms will be added.
 
 Requirements

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,13 +1,15 @@
 ---
-- name: Add letsencrypt repo
-  apt_repository:
-    repo: 'ppa:certbot/certbot'
-
 - name: Install letsencrypt
-  apt:
+  snap:
     name: certbot
     state: present
-    update_cache: yes
+    classic: yes
+
+- name: Make a certbot symlink in /usr/bin
+  file:
+    src: /snap/bin/certbot
+    dest: /usr/bin/certbot
+    state: link
 
 - name: Stop http service to issue certificate in standalone mode
   service:


### PR DESCRIPTION
## Purpose

- Snap will install more recent version of certbot and it's avaiable on
16.04, 18.04 and 20.04 so it's the more common and convenient variant.